### PR TITLE
HEARTH-1420 fixed support form and added protractor tests

### DIFF
--- a/app/assets/components/navigation/navigation.html
+++ b/app/assets/components/navigation/navigation.html
@@ -316,7 +316,7 @@
 				</a>
 
 				<div class="dropdown-container">
-					<a title="{{::'HEARTH.PROJECT_NAVIGATION_ITEM' | translate }}" class='icon-item' ng-class="{active: ['faq', 'taxes', 'terms', 'feedback', 'support-us'].indexOf(segment) > -1}" analytics-custom analytics-event="about page open" dropdown="#about-drop" hover="true" analytics-category="About" id="nav-about">
+					<a title="{{::'HEARTH.PROJECT_NAVIGATION_ITEM' | translate }}" class='icon-item' ng-class="{active: ['faq', 'taxes', 'terms', 'feedback', 'support-us'].indexOf(segment) > -1}" analytics-custom analytics-event="about page open" dropdown="#about-drop" hover="true" analytics-category="About" id="nav-about" test-beacon="hearth-project-dropdown">
 						<div class="inner-icon">
 							<span class="fa fa-question-circle"></span>
 							<span translate="HEARTH.PROJECT_NAVIGATION_ITEM"></span>
@@ -346,7 +346,7 @@
 							<a ui-sref="taxes" translate="HEARTH.TAXES.NAVIGATION_ITEM"></a>
 						</li>
 						<li>
-							<a ui-sref="feedback" translate="HEARTH.CONTACT_US.NAVIGATION_ITEM"></a>
+							<a ui-sref="feedback" translate="HEARTH.CONTACT_US.NAVIGATION_ITEM" test-beacon="hearth-contact-us-link"></a>
 						</li>
 						<li>
 							<a ui-sref="support-us" translate="HEARTH.SUPPORT_US.NAVIGATION_ITEM"></a>
@@ -394,7 +394,7 @@
 							<a ng-href="{{:: basePath }}support-us" translate="HEARTH.SUPPORT_US.NAVIGATION_ITEM"></a>
 						</li>
 						<li>
-							<a ng-href="{{:: basePath }}feedback" translate="HEARTH.CONTACT_US.NAVIGATION_ITEM"></a>
+							<a ng-href="{{:: basePath }}feedback" translate="HEARTH.CONTACT_US.NAVIGATION_ITEM" test-beacon="hearth-contact-us-link"></a>
 						</li>
 						<li class="divider"></li>
 						<li>

--- a/app/assets/pages/static/FeedbackCtrl.js
+++ b/app/assets/pages/static/FeedbackCtrl.js
@@ -49,10 +49,12 @@ angular.module('hearth.controllers').controller('FeedbackCtrl', [
 			var uploadUrl = $$config.apiPath + '/feedback';
 			$scope.sending = true;
 
-			MultipartForm.post(uploadUrl, $scope.feedback, $scope.file).success(function() {
+			MultipartForm.post(uploadUrl, $scope.feedback, $scope.file).then(function() {
+				// successfully send
 				$scope.sent = true;
 				$scope.sending = false;
-			}).error(function() {
+			}, function() {
+				// error sending
 				$scope.sending = false;
 				return $scope.init();
 			});

--- a/app/assets/pages/static/feedback.html
+++ b/app/assets/pages/static/feedback.html
@@ -2,7 +2,7 @@
 
 <div class="box">
 
-	<form name="feedbackForm" ng-submit="submit($event)" ng-show="!sent" with-errors novalidate>
+	<form name="feedbackForm" ng-submit="submit($event)" ng-show="!sent" with-errors novalidate test-beacon="hearth-feedback-form">
 		<div ng-show="fromAccountDelete" class="clearfix padding-2 successfully-sent" translate="AUTH.NOTIFY.SUCCESS_ACCOUNT_HAS_BEEN_DELETED"></div>
 		<p translate="HEARTH.FEEDBACK.TEXT"></p>
 		<h5 ng-show="fromAccountDelete" style="margin:0;" translate="HEARTH.FEEDBACK.REMOVING_ACCOUNT_FEEDBACK"></h5>
@@ -32,11 +32,11 @@
 		</div>
 	</form>
 
-	<div ng-show="sent">
+	<div ng-show="sent" test-beacon="hearth-feedback-success">
 		<div class="clearfix text-center successfully-sent" translate="HEARTH.FEEDBACK.NOTIFY.SUCCESS_SEND_FEEDBACK"></div>
 		<br />
 		<div style="text-align:center;">
-			<a href="" ng-click="init()" analytics-custom analytics-event="feedback form sent" analytics-category="Feedback" analytics-value="4" translate="HEARTH.FEEDBACK.ACTION_SEND_ANOTHER"></a>
+			<a ng-click="init()" analytics-custom analytics-event="feedback form sent" analytics-category="Feedback" analytics-value="4" translate="HEARTH.FEEDBACK.ACTION_SEND_ANOTHER"></a>
 		</div>
 	</div>
 

--- a/protractor-screenshots.js
+++ b/protractor-screenshots.js
@@ -18,6 +18,7 @@ exports.config = {
   directConnect: true,
 	specs: [
 		testFolder + 'unauth/marketplace.spec.js',
+    	testFolder + 'unauth/feedback-form.spec.js',		
 		// testFolder + 'auth/register.spec.js',
 		testFolder + 'auth/login.spec.js',
 		testFolder + 'auth/profile.spec.js',

--- a/protractor.js
+++ b/protractor.js
@@ -13,6 +13,7 @@ exports.config = {
 
   specs: [
     testFolder + 'unauth/marketplace.spec.js',
+    testFolder + 'unauth/feedback-form.spec.js',
     // testFolder + 'auth/register.spec.js',
     testFolder + 'auth/login.spec.js',
     testFolder + 'auth/profile.spec.js',

--- a/test/e2e/unauth/feedback-form.spec.js
+++ b/test/e2e/unauth/feedback-form.spec.js
@@ -1,0 +1,53 @@
+const beacon = require('../utils.js').beacon;
+
+describe('hearth support form', function () {
+
+  function navigateToFeedback() {
+    browser.actions().mouseMove(beacon('hearth-project-dropdown'), {x: 0, y: 0}).perform();
+    var topMenuLink = beacon('hearth-contact-us-link');
+    topMenuLink.click();
+  }
+
+  beforeEach(function () {
+    protractor.helpers.navigateTo('/');
+  });
+
+
+  // should be able to go to feedback from main page
+  it('should be able to navigate to feedback', function () {
+    navigateToFeedback();
+
+    var feedbackForm = beacon('hearth-feedback-form');
+    expect(feedbackForm.isDisplayed()).toBeTruthy();
+  });
+
+
+  // should fill the form and send it
+  it('should be able to fill the form', function () {
+    navigateToFeedback();
+
+    var feedbackForm = beacon('hearth-feedback-form');
+    var feedbackTextarea = feedbackForm.element(by.css('textarea'));
+    var feedbackEmailInput = feedbackForm.element(by.css('input[type="email"]'));
+    var submitButton = feedbackForm.element(by.css('button[type="submit"]'));
+    var successfullMessage = beacon('hearth-feedback-success');
+
+    expect(feedbackForm.isDisplayed()).toBeTruthy();
+    expect(successfullMessage.isDisplayed()).toBeFalsy();
+    expect(feedbackTextarea.isDisplayed()).toBeTruthy();
+    expect(submitButton.getAttribute('disabled')).toBe('true');
+
+    feedbackTextarea.sendKeys("$1bf6cc4c\r\nToto je generovaná zpráva z automatizovaných testů, neodpovídejte na ní.");
+    feedbackEmailInput.sendKeys("testovaci@mailinator.com");
+
+    expect(submitButton.getAttribute('disabled')).toBe(null);    
+
+    submitButton.click().then(function () {
+      expect(feedbackForm.isDisplayed()).toBeFalsy();
+      expect(successfullMessage.isDisplayed()).toBeTruthy();
+    });
+    
+  });
+
+
+});


### PR DESCRIPTION
A bug which caused unresponsive UI after message sent has been fixed, and a test added.

One noticable thing: when text sent to Hearth.net support email does contain string "$1bf6cc4c" (without quotes), it would be deleted instantly from the support mailbox. So it would not fill up the email and waste e-space ;)

